### PR TITLE
Fix `zt` to consider context.vim's context height

### DIFF
--- a/autoload/smooth_scroll.vim
+++ b/autoload/smooth_scroll.vim
@@ -56,7 +56,11 @@ function! smooth_scroll#top(visual)
 
   let cur_top = line('w0') + &scrolloff
   let target_top = line('.')
-  let num_down =  l:target_top - l:cur_top
+  let context_height = -1
+  if match(&runtimepath, 'context\.vim') != -1
+    let [_, context_height] = context#context#get(context#line#get_base_line(line('.')))
+  endif
+  let num_down =  l:target_top - l:cur_top - (l:context_height + 1)
   if l:num_down > 0
     call s:smooth_scroll('d', l:num_down, 0)
   endif

--- a/autoload/smooth_scroll.vim
+++ b/autoload/smooth_scroll.vim
@@ -59,7 +59,10 @@ function! smooth_scroll#top(visual)
   let context_height = 0
   if match(&runtimepath, 'context\.vim') != -1
     let [_, context_height] = context#context#get(context#line#get_base_line(line('.')))
-    let context_height += 1
+    " Make room for the context separator line
+    if context_height > 0
+      let context_height += 1
+    endif
   endif
   let num_down =  l:target_top - l:cur_top - l:context_height
   if l:num_down > 0

--- a/autoload/smooth_scroll.vim
+++ b/autoload/smooth_scroll.vim
@@ -56,11 +56,12 @@ function! smooth_scroll#top(visual)
 
   let cur_top = line('w0') + &scrolloff
   let target_top = line('.')
-  let context_height = -1
+  let context_height = 0
   if match(&runtimepath, 'context\.vim') != -1
     let [_, context_height] = context#context#get(context#line#get_base_line(line('.')))
+    let context_height += 1
   endif
-  let num_down =  l:target_top - l:cur_top - (l:context_height + 1)
+  let num_down =  l:target_top - l:cur_top - l:context_height
   if l:num_down > 0
     call s:smooth_scroll('d', l:num_down, 0)
   endif


### PR DESCRIPTION
When using [context.vim](https://github.com/wellle/context.vim), it is important that the number of lines to scroll takes account of the context height. This pull request aims to solve this issue.

The fix is based on https://github.com/wellle/context.vim/issues/128.

As this is my first contribution to a Vim plugin, please feel free to modify the code to adhere to your preferred style guide.